### PR TITLE
fixing specialist fee error in report

### DIFF
--- a/app/Models/MeetRegistration.php
+++ b/app/Models/MeetRegistration.php
@@ -4377,6 +4377,8 @@ class MeetRegistration extends Model
             foreach($auditEvent->scratch['athlete'] as $scratch)
             {
                 $scratch = (object) $scratch;
+                if(isset($scratch->events))
+                    continue;
                 $current_level = LevelRegistration::find($scratch->level_registration_id);
                 $bodyId = $current_level->level->sanctioning_body_id;
                 $at_info = [


### PR DESCRIPTION
Had an issue at model/meetRegistration file on line 4388 because it was considering scratched specialist as normal athlete. This PR has the tested fix.